### PR TITLE
Moved the scrollTop button higher

### DIFF
--- a/src/sharedComponents/ScrollTop/ScrollTop.module.scss
+++ b/src/sharedComponents/ScrollTop/ScrollTop.module.scss
@@ -8,7 +8,7 @@
   box-sizing: border-box;
   z-index: 200;
   .button {
-    transform: translateY(calc(100vh - 2* var(--contentMargin)));
+    transform: translateY(calc(100vh - 4* var(--contentMargin)));
     margin-left: auto;
     margin-right: var(--contentMargin);
     border-radius: 50%;


### PR DESCRIPTION
Moved the scrollTop button higher because it was hidden under navigation buttons on phones